### PR TITLE
Minor documentation additions

### DIFF
--- a/R/convert.r
+++ b/R/convert.r
@@ -8,7 +8,7 @@
 #' @param ... Arguments to be passed to \link{make.mask}.
 #' @inheritParams fit.ascr
 #'
-#' @return An object of class \code{mask}.
+#' @return An object of class \code{mask}. The object has two useful attributes: \code{area} which gives the area of each grid cell in hectares and \code{buffer} which gives the value of \code{buffer} supplied to this function.
 #'
 #' @seealso \link{convert.mask} to convert a mask compatible with the
 #'     \link{secr} package.

--- a/R/convert.r
+++ b/R/convert.r
@@ -16,6 +16,9 @@
 #' @examples
 #' mask <- create.mask(traps = example$traps, buffer = 20)
 #'
+#' # calculate the area of the mask (in hectares)
+#' mask_area <- attr(mask, "area") * nrow(mask)
+#'
 #' @export
 create.mask <- function(traps, buffer, ...){
     traps <- convert.traps(traps)

--- a/man/create.mask.Rd
+++ b/man/create.mask.Rd
@@ -16,7 +16,7 @@ edge of the generated mask.}
 \item{...}{Arguments to be passed to \link{make.mask}.}
 }
 \value{
-An object of class \code{mask}.
+An object of class \code{mask}. The object has two useful attributes: \code{area} which gives the area of each grid cell in hectares and \code{buffer} which gives the value of \code{buffer} supplied to this function.
 }
 \description{
 Creates a mask object to use with the function

--- a/man/create.mask.Rd
+++ b/man/create.mask.Rd
@@ -25,6 +25,9 @@ Creates a mask object to use with the function
 \examples{
 mask <- create.mask(traps = example$traps, buffer = 20)
 
+# calculate the area of the mask (in hectares)
+mask_area <- attr(mask, "area") * nrow(mask)
+
 }
 \seealso{
 \link{convert.mask} to convert a mask compatible with the


### PR DESCRIPTION
Here are a couple of documentation additions to the mask stuff in `ascr`:

1. added documentation for attributes of the object returned by `create.mask`
2. added an example of calculating size of mask area

No functionality changes.