### PR TITLE
boostrap bug fixes

### DIFF
--- a/R/boot.r
+++ b/R/boot.r
@@ -145,12 +145,12 @@ boot.ascr <- function(fit, N, prog = TRUE, n.cores = 1, M = 10000, infotypes = N
             ## Fitting model.
             fit.boot <- suppressWarnings(try(do.call("fit.ascr", args), silent = TRUE))
             ## If unconverged, refit model with default start values.
-            if (fit.boot$maxgrad < -0.01 | "try-error" %in% class(fit.boot)){
+            if ("try-error" %in% class(fit.boot) || fit.boot$maxgrad < -0.01){
                 args$sv <- NULL
                 fit.boot <- suppressWarnings(try(do.call("fit.ascr", args), silent = TRUE))
             }
             ## If still unconverged, give up and report NA.
-            if (fit.boot$maxgrad < -0.01 | "try-error" %in% class(fit.boot)){
+            if ("try-error" %in% class(fit.boot) || fit.boot$maxgrad < -0.01){
                 n.par <- length(fit$coefficients)
                 out <- rep(NA, n.par + 1)
             } else {

--- a/R/simcapt.r
+++ b/R/simcapt.r
@@ -361,7 +361,7 @@ sim.capt <- function(fit = NULL, traps = NULL, mask = NULL,
                                         nrow = n.popn, ncol = n.traps)
             }
             captures <- which(apply(full.bin.capt, 1, sum) > 0)
-            bin.capt <- full.bin.capt[captures, ]
+            bin.capt <- full.bin.capt[captures, , drop=FALSE]
             out <- list(bincapt = bin.capt)
         } else {
             if (ss.link == "identity"){


### PR DESCRIPTION
This patch fixes two minor 🐛 :

1. in `boot.ascr`: value of `maxgrad` was being checked before checking to see if it existed (using `try()`), so would fail. I reversed the order and used the "short circuit OR" (`||`) to stop the checking the value when it doesn't exist.
2. in `sim.capt`: when the capture history is only 1 row, the dimensions were dropped and the result simplified to a vector, this then impacts an `nrow()` call back in `boot.ascr()` causing it to crash.

😸 